### PR TITLE
Fix incorrect types in packer.

### DIFF
--- a/oftoast/OFtoaster.py
+++ b/oftoast/OFtoaster.py
@@ -16,7 +16,7 @@ def main(newdir,targetdir='.'):
     except:
         oldtable = {}
     jarray = {}
-    for file in iglob(targetdir / '**',recursive=True):
+    for file in iglob(str(targetdir / '**'),recursive=True):
         file = Path(file)
         if Path(file).is_dir():
             continue

--- a/oftoast/OFtoaster.py
+++ b/oftoast/OFtoaster.py
@@ -26,13 +26,13 @@ def main(newdir,targetdir='.'):
         fi.close()
         hash = hashlib.sha512(comp).hexdigest()
         try:
-            if oldtable[file][0] == hash:
+            if oldtable[str(file)][0] == hash:
                 print('its already there')
-                jarray[file] = oldtable[file]
+                jarray[str(file)] = oldtable[str(file)]
             else:
                 print('its changed')
-                rev = oldtable[file][1] + 1
-                jarray[file] = [hash, rev]
+                rev = oldtable[str(file)][1] + 1
+                jarray[str(file)] = [hash, rev]
         except KeyError:
             print('not there')
             jarray[str(file)] = [hash, 0]

--- a/oftoast/OFtoaster.py
+++ b/oftoast/OFtoaster.py
@@ -35,7 +35,7 @@ def main(newdir,targetdir='.'):
                 jarray[file] = [hash, rev]
         except KeyError:
             print('not there')
-            jarray[file] = [hash, 0]
+            jarray[str(file)] = [hash, 0]
         makedirs((newdir / file).parents[0], exist_ok=True)
         n = open((newdir / file),'wb')
         n.write(comp)


### PR DESCRIPTION
The scripts fails because PosixPaths aren't casted to strings where they should be. The JSON has been changed to use strings for the file keys as using naked PosixPaths is broken for me (tested on 3.9, and 3.11 on Linux.)